### PR TITLE
Potential fix for code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,5 +11,8 @@ trace.get_tracer_provider().add_span_processor(BatchSpanProcessor(otlp_exporter)
 
 app = create_app()
 
+import os
+
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_mode = os.getenv('FLASK_ENV') == 'development'
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/bilalobe/Opossum/security/code-scanning/1](https://github.com/bilalobe/Opossum/security/code-scanning/1)

To fix the issue, we should ensure that the Flask application does not run in debug mode in a production environment. This can be achieved by using an environment variable or configuration file to determine whether the application is running in development or production. The `debug` parameter should then be set accordingly.

The best approach is to use Python's `os` module to read an environment variable (e.g., `FLASK_ENV`) and set `debug=True` only if the environment is explicitly set to "development". This ensures that debug mode is disabled by default and only enabled when explicitly intended.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
