### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -77,8 +77,10 @@ def validate_request(model: type[BaseModel]):
                     status_code=400
                 )
             except Exception as e:
+                import logging
+                logging.error("An unexpected error occurred", exc_info=True)
                 return api_response(
-                    error=str(e),
+                    error="An internal server error occurred.",
                     status_code=500
                 )
 


### PR DESCRIPTION
Potential fix for [https://github.com/bilalobe/Opossum/security/code-scanning/2](https://github.com/bilalobe/Opossum/security/code-scanning/2)

To fix the issue, we will replace the direct exposure of the exception message (`str(e)`) with a generic error message. The detailed exception information will be logged on the server for debugging purposes. This ensures that sensitive information is not exposed to external users while still allowing developers to diagnose issues.

Steps to implement the fix:
1. Replace the `str(e)` in the `api_response` call on line 81 with a generic error message like "An internal server error occurred."
2. Log the exception details (stack trace) on the server using Python's `logging` module.
3. Add an import for the `logging` module if it is not already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
